### PR TITLE
Add in collections.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
+#![cfg_attr(target_os="linux", feature(collections))]
+
 #[cfg(target_os="linux")]
 extern crate libc;
 #[cfg(target_os="linux")]


### PR DESCRIPTION
This was removed in #3, but incorrectly. This adds it back for linux
only, which fixes the warning on OS X and keeps the crate building on Linux.

Fixes #4.
