### PR TITLE
Add aarch64-unknown-linux-gnu support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ features = ["xlib", "xmu"]
 [target.arm-unknown-linux-gnueabihf.dependencies.x11]
 version = "2.0.0"
 features = ["xlib", "xmu"]
+
+[target.aarch64-unknown-linux-gnu.dependencies.x11]
+version = "1.1.1"
+features = ["xlib", "xmu"]

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -67,8 +67,8 @@ impl ClipboardContextGetter {
         fn xcout(dpy: *mut Display, win: Window, evt: &mut XEvent,
                 sel: Atom, target: Atom, type_: &mut Atom, dest: &mut Vec<u8>,
                 context: &mut XCOutState) {
-            let pty_atom = unsafe { XInternAtom(dpy, b"SERVO_CLIPBOARD_OUT\0".as_ptr() as *mut i8, 0) };
-            let incr_atom = unsafe { XInternAtom(dpy, b"INCR\0".as_ptr() as *mut i8, 0) };
+            let pty_atom = unsafe { XInternAtom(dpy, b"SERVO_CLIPBOARD_OUT\0".as_ptr() as *mut ::libc::c_char, 0) };
+            let incr_atom = unsafe { XInternAtom(dpy, b"INCR\0".as_ptr() as *mut ::libc::c_char, 0) };
 
             let mut buffer: *mut c_uchar = ptr::null_mut();
             let mut pty_format: c_int = 0;


### PR DESCRIPTION
- Adding x11 dependency
- Replacing `i8` with `::libc::c_char` (since `c_char` can be
  unsigned on some platforms, aarch64 is one of them)
