### PR TITLE
Aftermath of aarch64 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ version = "2.0.0"
 features = ["xlib", "xmu"]
 
 [target.aarch64-unknown-linux-gnu.dependencies.x11]
-version = "1.1.1"
+version = "2.0.0"
 features = ["xlib", "xmu"]

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -333,8 +333,8 @@ impl ClipboardContext {
             let mut pty = unsafe { uninitialized() };
             let target = XA_STRING;
 
-            let targets = unsafe { XInternAtom(display, b"TARGETS\0".as_ptr() as *mut i8, 0) };
-            let incr_atom = unsafe { XInternAtom(display, b"INCR\0".as_ptr() as *mut i8, 0) };
+            let targets = unsafe { XInternAtom(display, b"TARGETS\0".as_ptr() as *mut ::libc::c_char, 0) };
+            let incr_atom = unsafe { XInternAtom(display, b"INCR\0".as_ptr() as *mut ::libc::c_char, 0) };
 
             // https://github.com/rust-lang/rust/issues/25343
             'outer: loop {


### PR DESCRIPTION
Previous patch added x11-rs 1.1.1 dependency but now 2.0.0 is
required, and also missed an `i8` vs `c_char` issue.
