### PR TITLE
Remove some unsafe blocks from osx_clipboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ clipboard-win = "1.5.1"
 clipboard-win = "1.5.1"
 
 [target.i686-apple-darwin.dependencies]
-objc = "0.1.5"
-objc_id = "0.0.1"
-objc-foundation = "0.0.1"
+objc = "0.1.6"
+objc_id = "0.0.2"
+objc-foundation = "0.0.2"
 
 [target.x86_64-apple-darwin.dependencies]
-objc = "0.1.5"
-objc_id = "0.0.1"
-objc-foundation = "0.0.1"
+objc = "0.1.6"
+objc_id = "0.0.2"
+objc-foundation = "0.0.2"
 
 [target.i686-unknown-linux-gnu.dependencies.x11]
 version = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,10 @@ pub use osx_clipboard::*;
 mod nop_clipboard;
 #[cfg(not(any(target_os="linux", windows, target_os="macos")))]
 pub use nop_clipboard::*;
+
+#[test]
+fn test_clipboard() {
+    let mut ctx = ClipboardContext::new().unwrap();
+    ctx.set_contents("some string".to_owned()).unwrap();
+    assert!(ctx.get_contents().unwrap() == "some string");
+}


### PR DESCRIPTION
First off, I think it's pretty cool that you've found objc-foundation useful :) As I was reading over the code, I noticed that a lot of the unsafe blocks in `get_contents` could be removed by using some of the methods of `NSArray`, so here's a pull request to do that!

In the process, I also updated objc-foundation to 0.0.2, which is compatible with objc 0.1.6. I also added a simple little test for the clipboard functionality, just so I could verify I didn't break anything.

If this is too many changes lumped into one pull request, let me know and I'm happy to remove parts.
