### PR TITLE
Win: set_contents() accepts AsRef<OsStr>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "clipboard"
 version = "0.0.3"
 authors = ["Avi Weinstock <aweinstock314@gmail.com>"]
@@ -8,10 +7,10 @@ authors = ["Avi Weinstock <aweinstock314@gmail.com>"]
 libc = "*"
 
 [target.i686-pc-windows-gnu.dependencies]
-clipboard-win = "1.5.1"
+clipboard-win = "1.6.0"
 
 [target.x86_64-pc-windows-gnu.dependencies]
-clipboard-win = "1.5.1"
+clipboard-win = "1.6.0"
 
 [target.i686-apple-darwin.dependencies]
 objc = "0.1.6"

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -1,17 +1,23 @@
 use clipboard_win::{get_clipboard_string, set_clipboard};
 
 use std::error::Error;
+use std::ffi::OsStr;
 
 pub struct ClipboardContext;
 
 impl ClipboardContext {
+    #[inline]
     pub fn new() -> Result<ClipboardContext, Box<Error>> {
         Ok(ClipboardContext)
     }
+
+    #[inline]
     pub fn get_contents(&self) -> Result<String, Box<Error>> {
         Ok(try!(get_clipboard_string()))
     }
-    pub fn set_contents(&mut self, data: String) -> Result<(), Box<Error>> {
-        Ok(try!(set_clipboard(&data)))
+
+    #[inline]
+    pub fn set_contents<T: AsRef<OsStr>>(&mut self, data: T) -> Result<(), Box<Error>> {
+        Ok(try!(set_clipboard(data.as_ref())))
     }
 }


### PR DESCRIPTION
This commit makes `set_contents()` accept the argument with the same signature as `clipboard_win::set_clipboard()`
It will at least accept any reference to String and str

It may be better alternative to accept `AsRef<str>`
