### PR TITLE
Don't chdir on X11.

### DIFF
--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -233,10 +233,12 @@ impl ClipboardContextSetter {
             return Err(err("XExtendedMaxRequestSize/XMaxRequestSize"));
         }
 
+        /* TODO: Do this in the background process when forking a separate process is implemneted.
         // chdir to / in case the directory of the program is removed/unmounted
         if let Err(_) = set_current_dir(Path::new("/")) {
             return Err(err("set_current_dir"));
         }
+        */
 
         Ok(ClipboardContextSetter {
             display: dpy,


### PR DESCRIPTION
This code is based on xclip's background server code, but it doesn't make sense without a separate server process.  It changes the behavior of the main process in a surprising way.
