### PR TITLE
Add ClipboardProvider trait, expose ClipboardContext as a type alias …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "clipboard"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Avi Weinstock <aweinstock314@gmail.com>"]
 description = "rust-clipboard is a cross-platform library for getting and setting the contents of the OS-level clipboard."
 repository = "https://github.com/aweinstock314/rust-clipboard"
@@ -19,4 +19,3 @@ objc-foundation = "0.1"
 [target.'cfg(target_os = "linux")'.dependencies.x11]
 version = "2.3.0"
 features = ["xlib", "xmu"]
-

--- a/README.md
+++ b/README.md
@@ -18,21 +18,22 @@ sudo apt-get install xorg-dev
 fn example() {
     let mut ctx = ClipboardContext::new().unwrap();
     println!("{}", ctx.get_contents());
-    ctx.set_contents(&"some string");
+    ctx.set_contents("some string".to_owned());
 }
 ```
 
 ## API
 
+The `ClipboardProvider` trait has the following functions:
 ```rust
-fn new() -> Result<ClipboardContext, Box<Error>>
-fn get_contents(&ClipboardContext) -> Result<String, Box<Error>>
-fn set_contents(&mut ClipboardContext, String) -> Result<(), Box<Error>>
+fn new() -> Result<Self, Box<Error>>;
+fn get_contents(&mut self) -> Result<String, Box<Error>>;
+fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
 ```
 
-`ClipboardContext` is an opaque struct that is defined in different ways based on the OS via conditional compilation.
+`ClipboardContext` a type alias for one of {`WindowsClipboardContext`, `OSXClipboardContext`, `X11ClipboardContext`, `NopClipboardContext`}, all of which implement `ClipboardProvider`. Which concrete type is chosen for `ClipboardContext` depends on the OS (via conditional compilation).
 
 ## License
 Since the x11 backend contains code derived from xclip (which is GPLv2), rust-clipboard must currently be treated as GPLv2.
-I plan to rewrite `x11-clipboard.rs` by strictly referencing the ICCCM standard, and relicense to Apache2.
+I plan to rewrite `x11_clipboard.rs` by strictly referencing the ICCCM standard, and relicense to Apache2.
 All the other code in `rust-clipboard` may be treated as Apache2.

--- a/src/common.rs
+++ b/src/common.rs
@@ -19,3 +19,15 @@ use std::error::Error;
 pub fn err(s: &str) -> Box<Error> {
     Box::<Error+Send+Sync>::from(s)
 }
+
+/// Trait for clipboard access
+pub trait ClipboardProvider: Sized {
+    /// Create a context with which to access the clipboard
+    // TODO: consider replacing Box<Error> with an associated type?
+    fn new() -> Result<Self, Box<Error>>;
+    /// Method to get the clipboard contents as a String
+    fn get_contents(&mut self) -> Result<String, Box<Error>>;
+    /// Method to set the clipboard contents as a String
+    fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
+    // TODO: come up with some platform-agnostic API for richer types than just strings (c.f. issue #31)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,28 +33,28 @@ extern crate objc_id;
 #[cfg(target_os="macos")]
 extern crate objc_foundation;
 
-mod util;
+mod common;
+pub use common::ClipboardProvider;
 
 #[cfg(target_os="linux")]
-mod x11_clipboard;
+pub mod x11_clipboard;
+
+#[cfg(windows)]
+pub mod windows_clipboard;
+
+#[cfg(target_os="macos")]
+pub mod osx_clipboard;
+
+pub mod nop_clipboard;
+
 #[cfg(target_os="linux")]
-pub use x11_clipboard::*;
-
+pub type ClipboardContext = x11_clipboard::X11ClipboardContext;
 #[cfg(windows)]
-mod windows_clipboard;
-#[cfg(windows)]
-pub use windows_clipboard::*;
-
+pub type ClipboardContext = windows_clipboard::WindowsClipboardContext;
 #[cfg(target_os="macos")]
-mod osx_clipboard;
-#[cfg(target_os="macos")]
-pub use osx_clipboard::*;
-
-
+pub type ClipboardContext = osx_clipboard::OSXClipboardContext;
 #[cfg(not(any(target_os="linux", windows, target_os="macos")))]
-mod nop_clipboard;
-#[cfg(not(any(target_os="linux", windows, target_os="macos")))]
-pub use nop_clipboard::*;
+pub type ClipboardContext = nop_clipboard::NopClipboardContext;
 
 #[test]
 fn test_clipboard() {

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -14,17 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-pub struct ClipboardContext;
+use common::ClipboardProvider;
+use std::error::Error;
 
-impl ClipboardContext {
-    pub fn new() -> Result<ClipboardContext, &'static str> {
-        Ok(ClipboardContext)
+pub struct NopClipboardContext;
+
+impl ClipboardProvider for NopClipboardContext {
+    fn new() -> Result<NopClipboardContext, Box<Error>> {
+        Ok(NopClipboardContext)
     }
-    pub fn get_contents(&self) -> Result<String, &str> {
+    fn get_contents(&mut self) -> Result<String, Box<Error>> {
         println!("Attempting to get the contents of the clipboard, which hasn't yet been implemented on this platform.");
         Ok("".to_string())
     }
-    pub fn set_contents(&self, _: String) -> Result<(), &str> {
+    fn set_contents(&mut self, _: String) -> Result<(), Box<Error>> {
         println!("Attempting to set the contents of the clipboard, which hasn't yet been implemented on this platform.");
         Ok(())
     }

--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use util::err;
+use common::*;
 use objc::runtime::{Object, Class};
 use objc_foundation::{INSArray, INSString, INSObject};
 use objc_foundation::{NSArray, NSDictionary, NSString, NSObject};
@@ -22,7 +22,7 @@ use objc_id::{Id, Owned};
 use std::error::Error;
 use std::mem::transmute;
 
-pub struct ClipboardContext {
+pub struct OSXClipboardContext {
     pasteboard: Id<Object>,
 }
 
@@ -30,19 +30,19 @@ pub struct ClipboardContext {
 #[link(name = "AppKit", kind = "framework")]
 extern {}
 
-impl ClipboardContext {
-    pub fn new() -> Result<ClipboardContext, Box<Error>> {
+impl ClipboardProvider for OSXClipboardContext {
+    pub fn new() -> Result<OSXClipboardContext, Box<Error>> {
         let cls = try!(Class::get("NSPasteboard").ok_or(err("Class::get(\"NSPasteboard\")")));
         let pasteboard: *mut Object = unsafe { msg_send![cls, generalPasteboard] };
         if pasteboard.is_null() {
             return Err(err("NSPasteboard#generalPasteboard returned null"));
         }
         let pasteboard: Id<Object> = unsafe { Id::from_ptr(pasteboard) };
-        Ok(ClipboardContext {
+        Ok(OSXClipboardContext {
             pasteboard: pasteboard,
         })
     }
-    pub fn get_contents(&self) -> Result<String, Box<Error>> {
+    pub fn get_contents(&mut self) -> Result<String, Box<Error>> {
         let string_class: Id<NSObject> = {
             let cls: Id<Class> = unsafe { Id::from_ptr(class("NSString")) };
             unsafe { transmute(cls) }

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -16,15 +16,16 @@ limitations under the License.
 
 use clipboard_win::Clipboard;
 
+use common::ClipboardProvider;
 use std::error::Error;
 
-pub struct ClipboardContext(Clipboard);
+pub struct WindowsClipboardContext(Clipboard);
 
-impl ClipboardContext {
-    pub fn new() -> Result<ClipboardContext, Box<Error>> {
-        Ok(ClipboardContext(Clipboard::new()?))
+impl WindowsClipboardContext {
+    pub fn new() -> Result<Self, Box<Error>> {
+        Ok(WindowsClipboardContext(Clipboard::new()?))
     }
-    pub fn get_contents(&self) -> Result<String, Box<Error>> {
+    pub fn get_contents(&mut self) -> Result<String, Box<Error>> {
         Ok(self.0.get_string()?)
     }
     pub fn set_contents(&mut self, data: String) -> Result<(), Box<Error>> {


### PR DESCRIPTION
…(refactoring to eventually allow multiple backends as a runtime choice).