### PR TITLE
Upgrade x11-clipboard to v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-x11-clipboard = "0.1"
+x11-clipboard = "0.2"


### PR DESCRIPTION
This includes [an xcb fix](https://github.com/rtbo/rust-xcb/issues/40) that fixes compilation on rustc 1.21.0-beta.1.