### PR TITLE
Add support for x11 primary selection.

### DIFF
--- a/examples/primary_selection.rs
+++ b/examples/primary_selection.rs
@@ -1,0 +1,17 @@
+extern crate clipboard;
+
+use clipboard::ClipboardProvider;
+#[cfg(target_os = "linux")]
+use clipboard::x11_clipboard::{X11ClipboardContext, Primary};
+
+fn main() {
+    if cfg!(not(target_os = "linux")) {
+        println!("Primary selection is only available under linux!");
+        return;
+    }
+    let mut ctx: X11ClipboardContext<Primary> = ClipboardProvider::new().unwrap();
+
+    let the_string = "Hello, world!";
+
+    ctx.set_contents(the_string.to_owned()).unwrap();
+}

--- a/examples/primary_selection.rs
+++ b/examples/primary_selection.rs
@@ -4,14 +4,16 @@ use clipboard::ClipboardProvider;
 #[cfg(target_os = "linux")]
 use clipboard::x11_clipboard::{X11ClipboardContext, Primary};
 
+#[cfg(target_os = "linux")]
 fn main() {
-    if cfg!(not(target_os = "linux")) {
-        println!("Primary selection is only available under linux!");
-        return;
-    }
     let mut ctx: X11ClipboardContext<Primary> = ClipboardProvider::new().unwrap();
 
     let the_string = "Hello, world!";
 
     ctx.set_contents(the_string.to_owned()).unwrap();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    println!("Primary selection is only available under linux!");
 }


### PR DESCRIPTION
A backwards compatible implementation of the X11 primary selection, allowing for linux-specific code to copy to the primary selection instead of the clipboard. Usage example included.