### PR TITLE
Fix #50: Use family=unix minus macos, instead of os=unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: rust
-sudo: required
-matrix:
-    include:
-        - os: osx
-#        # TODO: figure out how to get headless X11 working
-#        - install:
-#            - sudo apt-get install xorg-dev
+
+os:
+- linux
+- osx
+
+# TODO: figure out how to get headless X11 working
+script: |
+  #!/bin/bash
+  cargo build --verbose
+  if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+    cargo build --tests --verbose
+  else
+    cargo test --verbose
+  fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
 
-[target.'cfg(target_os = "unix")'.dependencies]
+[target.'cfg(all(unix, not(target_os="macos")))'.dependencies]
 x11-clipboard = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
-#[cfg(target_os="unix")]
+#[cfg(all(unix, not(target_os="macos")))]
 extern crate x11_clipboard as x11_clipboard_crate;
 
 #[cfg(windows)]
@@ -36,7 +36,7 @@ extern crate objc_foundation;
 mod common;
 pub use common::ClipboardProvider;
 
-#[cfg(target_os="unix")]
+#[cfg(all(unix, not(target_os="macos")))]
 pub mod x11_clipboard;
 
 #[cfg(windows)]
@@ -47,13 +47,13 @@ pub mod osx_clipboard;
 
 pub mod nop_clipboard;
 
-#[cfg(target_os="unix")]
+#[cfg(all(unix, not(target_os="macos")))]
 pub type ClipboardContext = x11_clipboard::X11ClipboardContext;
 #[cfg(windows)]
 pub type ClipboardContext = windows_clipboard::WindowsClipboardContext;
 #[cfg(target_os="macos")]
 pub type ClipboardContext = osx_clipboard::OSXClipboardContext;
-#[cfg(not(any(target_os="unix", windows, target_os="macos")))]
+#[cfg(not(any(unix, windows, target_os="macos")))]
 pub type ClipboardContext = nop_clipboard::NopClipboardContext;
 
 #[test]


### PR DESCRIPTION
Added linux travis test-compile which will at least catch such conditional compilations issues in future.