### PR TITLE
Fix "warning: type annotations needed"

### DIFF
--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -48,7 +48,7 @@ impl ClipboardProvider for OSXClipboardContext {
         let classes: Id<NSArray<NSObject, Owned>> = NSArray::from_vec(vec![string_class]);
         let options: Id<NSDictionary<NSObject, NSObject>> = NSDictionary::new();
         let string_array: Id<NSArray<NSString>> = unsafe {
-            let obj: *mut _ =
+            let obj: *mut NSArray<NSString> =
                 msg_send![self.pasteboard, readObjectsForClasses:&*classes options:&*options];
             if obj.is_null() {
                 return Err(err("pasteboard#readObjectsForClasses:options: returned null"));


### PR DESCRIPTION
was poking around with this on OSX and noticed the following warning:

```
$ cargo build --verbose
       Fresh libc v0.2.42
       Fresh block v0.1.6
       Fresh malloc_buf v0.0.6
       Fresh objc v0.2.2
       Fresh objc_id v0.1.0
       Fresh objc-foundation v0.1.1
   Compiling clipboard ...
warning: type annotations needed
  --> /Users/ricky/projects/rust-clipboard/src/osx_clipboard.rs:53:20
   |
53 |             if obj.is_null() {
   |                    ^^^^^^^
   |
   = note: #[warn(tyvar_behind_raw_pointer)] on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
   = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
```

this change effectively removes the warning (which will become a hard error soon i guess)