### PR TITLE
feat(*): get non-string contents from clipboard for OSX

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -20,6 +20,15 @@ pub fn err(s: &str) -> Box<Error> {
     Box::<Error + Send + Sync>::from(s)
 }
 
+pub enum ClipboardContent {
+    Utf8(String),
+    Tiff(Vec<u8>),
+    // TODO: extend this enum by more types
+    // Url, RichText, ....
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
 /// Trait for clipboard access
 pub trait ClipboardProvider: Sized {
     /// Create a context with which to access the clipboard
@@ -29,6 +38,6 @@ pub trait ClipboardProvider: Sized {
     fn get_contents(&mut self) -> Result<String, Box<Error>>;
     /// Method to set the clipboard contents as a String
     fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
-    // TODO: come up with some platform-agnostic API for richer types
-    // than just strings (c.f. issue #31)
+    /// Method to get clipboard contents not necessarily string
+    fn get_binary_contents(&mut self) -> Result<ClipboardContent, Box<Error>>;
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -39,5 +39,5 @@ pub trait ClipboardProvider: Sized {
     /// Method to set the clipboard contents as a String
     fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
     /// Method to get clipboard contents not necessarily string
-    fn get_binary_contents(&mut self) -> Result<ClipboardContent, Box<Error>>;
+    fn get_binary_contents(&mut self) -> Result<Option<ClipboardContent>, Box<Error>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate objc_foundation;
 
 mod common;
 pub use common::ClipboardProvider;
+pub use common::ClipboardContent;
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android"))))]
 pub mod x11_clipboard;

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use common::ClipboardProvider;
+use common::ClipboardContent;
 use std::error::Error;
 
 pub struct NopClipboardContext;
@@ -27,6 +28,11 @@ impl ClipboardProvider for NopClipboardContext {
         println!("Attempting to get the contents of the clipboard, which hasn't yet been \
                   implemented on this platform.");
         Ok("".to_string())
+    }
+    fn get_binary_contents(&mut self) -> Result<ClipboardContent, Box<Error>> {
+        println!("Attempting to get the contents of the clipboard, which hasn't yet been \
+                  implemented on this platform.");
+        Ok(ClipboardContent::__Nonexhaustive)
     }
     fn set_contents(&mut self, _: String) -> Result<(), Box<Error>> {
         println!("Attempting to set the contents of the clipboard, which hasn't yet been \

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -29,10 +29,10 @@ impl ClipboardProvider for NopClipboardContext {
                   implemented on this platform.");
         Ok("".to_string())
     }
-    fn get_binary_contents(&mut self) -> Result<ClipboardContent, Box<Error>> {
+    fn get_binary_contents(&mut self) -> Result<Option<ClipboardContent>, Box<Error>> {
         println!("Attempting to get the contents of the clipboard, which hasn't yet been \
                   implemented on this platform.");
-        Ok(ClipboardContent::__Nonexhaustive)
+        Ok(None)
     }
     fn set_contents(&mut self, _: String) -> Result<(), Box<Error>> {
         println!("Attempting to set the contents of the clipboard, which hasn't yet been \

--- a/src/osx_clipboard.rs
+++ b/src/osx_clipboard.rs
@@ -61,6 +61,55 @@ impl ClipboardProvider for OSXClipboardContext {
             Ok(string_array[0].as_str().to_owned())
         }
     }
+    fn get_binary_contents(&mut self) -> Result<ClipboardContent, Box<Error>> {
+        let string_class: Id<NSObject> = {
+            let cls: Id<Class> = unsafe { Id::from_ptr(class("NSString")) };
+            unsafe { transmute(cls) }
+        };
+        let image_class: Id<NSObject> = {
+            let cls: Id<Class> = unsafe { Id::from_ptr(class("NSImage")) };
+            unsafe { transmute(cls) }
+        };
+        let url_class: Id<NSObject> = {
+            let cls: Id<Class> = unsafe { Id::from_ptr(class("NSURL")) };
+            unsafe { transmute(cls) }
+        };
+        let classes = vec![url_class, image_class, string_class];
+        let classes: Id<NSArray<NSObject, Owned>> = NSArray::from_vec(classes);
+        let options: Id<NSDictionary<NSObject, NSObject>> = NSDictionary::new();
+        let contents: Id<NSArray<NSObject>> = unsafe {
+            let obj: *mut NSArray<NSObject> =
+                msg_send![self.pasteboard, readObjectsForClasses:&*classes options:&*options];
+            if obj.is_null() {
+                return Err(err("pasteboard#readObjectsForClasses:options: returned null"));
+            }
+            Id::from_ptr(obj)
+        };
+        if contents.count() == 0 {
+            Err(err("pasteboard#readObjectsForClasses:options: returned empty"))
+        } else {
+            let obj = &contents[0];
+            if obj.is_kind_of(Class::get("NSString").unwrap()) {
+                let s: &NSString = unsafe { transmute(obj) };
+                Ok(ClipboardContent::Utf8(s.as_str().to_owned()))
+            } else if obj.is_kind_of(Class::get("NSImage").unwrap()) {
+                let tiff: &NSArray<NSObject> = unsafe { msg_send![obj, TIFFRepresentation] };
+                let len: usize = unsafe { msg_send![tiff, length] };
+                let bytes: *const u8 = unsafe { msg_send![tiff, bytes] };
+                let vec = unsafe { std::slice::from_raw_parts(bytes, len) };
+                // Here we copy the entire &[u8] into a new owned `Vec`
+                // Is there another way that doesn't copy multiple megabytes?
+                Ok(ClipboardContent::Tiff(vec.into()))
+            } else if obj.is_kind_of(Class::get("NSURL").unwrap()) {
+                let s: &NSString = unsafe { msg_send![obj, absoluteString] };
+                Ok(ClipboardContent::Utf8(s.as_str().to_owned()))
+            } else {
+                // let cls: &Class = unsafe { msg_send![obj, class] };
+                // println!("{}", cls.name());
+                Err(err("pasteboard#readObjectsForClasses:options: returned unknown class"))
+            }
+        }
+    }
     fn set_contents(&mut self, data: String) -> Result<(), Box<Error>> {
         let string_array = NSArray::from_vec(vec![NSString::from_str(&data)]);
         let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };


### PR DESCRIPTION
Hi, this addresses in part issue #31, and #46.

Some things I feel may be done differently:

1. I'm currently using a non-exhaustive enum, arguably this may not be the "best" cross-platform way. It may make sense to work with MIME types / Content-Types, however this offloads some work to the caller. Also, if the user copies a file from `Finder` (OS X), it will be a `NSURL` instead of a `String`, which cannot be captured as a mime type.
2. I'm currently copying the entire `&[u8]` from the objc memory (I added a comment) to an owned `Vec` which is very inefficient (small clipboards I experimented with when screen capping windows were >18MB). Not sure what's the best approach here

This is also just for OSX, happy for your feedback. For windows, it should be trivial as far as I can tell, since the `clipboard-win` crate exposes an API for this already