### PR TITLE
Fix compile error on wasm32-unknown-emscripten target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
 
-[target.'cfg(all(unix, not(any(target_os="macos", target_os="android"))))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 x11-clipboard = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
-#[cfg(all(unix, not(any(target_os="macos", target_os="android"))))]
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 extern crate x11_clipboard as x11_clipboard_crate;
 
 #[cfg(windows)]
@@ -36,7 +36,7 @@ extern crate objc_foundation;
 mod common;
 pub use common::ClipboardProvider;
 
-#[cfg(all(unix, not(any(target_os="macos", target_os="android"))))]
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 pub mod x11_clipboard;
 
 #[cfg(windows)]
@@ -47,7 +47,7 @@ pub mod osx_clipboard;
 
 pub mod nop_clipboard;
 
-#[cfg(all(unix, not(any(target_os="macos", target_os="android"))))]
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 pub type ClipboardContext = x11_clipboard::X11ClipboardContext;
 #[cfg(windows)]
 pub type ClipboardContext = windows_clipboard::WindowsClipboardContext;
@@ -55,7 +55,7 @@ pub type ClipboardContext = windows_clipboard::WindowsClipboardContext;
 pub type ClipboardContext = osx_clipboard::OSXClipboardContext;
 #[cfg(target_os="android")]
 pub type ClipboardContext = nop_clipboard::NopClipboardContext; // TODO: implement AndroidClipboardContext (see #52)
-#[cfg(not(any(unix, windows, target_os="macos", target_os="android")))]
+#[cfg(not(any(unix, windows, target_os="macos", target_os="android", target_os="emscripten")))]
 pub type ClipboardContext = nop_clipboard::NopClipboardContext;
 
 #[test]


### PR DESCRIPTION
rust-clipboard fails to build with the wasm32-unknown-emscripten target since it tries to build X clipboard support:

```
$ cargo build --target wasm32-unknown-emscripten
   Compiling xcb v0.8.2                                                                                                                                                      
error: failed to run custom build command for `xcb v0.8.2`                                                                                                                   
process didn't exit successfully: `rust-clipboard/target/debug/build/xcb-f6f24f9a96d825ba/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Unable to find build dependency python3: Os { code: 2, kind: NotFound, message: "No such file or directory" }', libcore/result.rs:1009:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

Since emscripten is recognized as "unix", but like macos and android it doesn't have an X11 clipboard, this pull request adds "emscripten" to the target_os exclusion for cfg unix:

```rust
#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
```

and the crate compiles with no errors