### PR TITLE
Wayland support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 x11-clipboard = "0.3"
+smithay-clipboard = "0.1"
+wayland-client = { version = "0.22", features = ["dlopen"] }
+
+[target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dev-dependencies]
+smithay-client-toolkit = "0.5"
+andrew = "0.2"

--- a/examples/wayland.rs
+++ b/examples/wayland.rs
@@ -1,0 +1,272 @@
+extern crate clipboard;
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate andrew;
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate smithay_client_toolkit as sctk;
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::{atomic, Arc, Mutex};
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+use sctk::reexports::client::protocol::{wl_shm, wl_surface};
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+use sctk::utils::MemPool;
+
+
+#[cfg(not(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten")))))]
+fn main() {
+    panic!("This example only works on unix platforms")
+}
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+fn main() {
+    use clipboard::wayland_clipboard::WaylandClipboardContext;
+    use sctk::keyboard::{map_keyboard_auto, Event as KbEvent, KeyState};
+    use sctk::utils::DoubleMemPool;
+    use sctk::window::{ConceptFrame, Event as WEvent, Window};
+    use sctk::Environment;
+
+    use sctk::reexports::client::protocol::wl_seat;
+    use sctk::reexports::client::{Display, NewProxy};
+
+    use andrew::text::fontconfig;
+
+    let (display, mut event_queue) =
+        Display::connect_to_env().expect("Failed to connect to the wayland server.");
+    let env = Environment::from_display(&*display, &mut event_queue).unwrap();
+
+    let mut ctx = WaylandClipboardContext::new(&display).unwrap();
+    let cb_contents = Arc::new(Mutex::new(String::new()));
+
+    let seat_name = Arc::new(Mutex::new(String::new()));
+    let seat_name_clone = seat_name.clone();
+    let seat = env
+        .manager
+        .instantiate_range(2, 6, move |proxy| {
+            proxy.implement_closure(
+                move |event, _| {
+                    if let wl_seat::Event::Name { name } = event {
+                        *seat_name_clone.lock().unwrap() = dbg!(name);
+                    }
+                },
+                (),
+            )
+        })
+        .unwrap();
+
+    let need_redraw = Arc::new(atomic::AtomicBool::new(false));
+    let need_redraw_clone = need_redraw.clone();
+    let cb_contents_clone = cb_contents.clone();
+    map_keyboard_auto(&seat, move |event: KbEvent, _| {
+        if let KbEvent::Key {
+            state: KeyState::Pressed,
+            utf8: Some(text),
+            ..
+        } = event
+        {
+            if text == " " {
+                println!("get");
+                *cb_contents_clone.lock().unwrap() = dbg!(ctx.get_contents().unwrap());
+                need_redraw_clone.store(true, atomic::Ordering::Relaxed)
+            } else if text == "s" {
+                println!("set");
+                ctx.set_contents(
+                    "This is an example text thats been copied to the wayland clipboard :)"
+                        .to_string(),
+                )
+                .unwrap();
+            }
+        }
+    })
+    .unwrap();
+
+    let mut dimensions = (320u32, 240u32);
+    let surface = env
+        .compositor
+        .create_surface(NewProxy::implement_dummy)
+        .unwrap();
+
+    let next_action = Arc::new(Mutex::new(None::<WEvent>));
+
+    let waction = next_action.clone();
+    let mut window = Window::<ConceptFrame>::init_from_env(&env, surface, dimensions, move |evt| {
+        let mut next_action = waction.lock().unwrap();
+        // Keep last event in priority order : Close > Configure > Refresh
+        let replace = match (&evt, &*next_action) {
+            (_, &None)
+            | (_, &Some(WEvent::Refresh))
+            | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
+            | (&WEvent::Close, _) => true,
+            _ => false,
+        };
+        if replace {
+            *next_action = Some(evt);
+        }
+    })
+    .expect("Failed to create a window !");
+
+    window.new_seat(&seat);
+    window.set_title("Clipboard".to_string());
+
+    let mut pools = DoubleMemPool::new(&env.shm, || {}).expect("Failed to create a memory pool !");
+
+    let mut font_data = Vec::new();
+    std::fs::File::open(
+        &fontconfig::FontConfig::new()
+            .unwrap()
+            .get_regular_family_fonts("sans")
+            .unwrap()[0],
+    )
+    .unwrap()
+    .read_to_end(&mut font_data)
+    .unwrap();
+
+    if !env.shell.needs_configure() {
+        // initial draw to bootstrap on wl_shell
+        if let Some(pool) = pools.pool() {
+            redraw(
+                pool,
+                window.surface(),
+                dimensions,
+                &font_data,
+                "".to_string(),
+            );
+        }
+        window.refresh();
+    }
+
+    loop {
+        match next_action.lock().unwrap().take() {
+            Some(WEvent::Close) => break,
+            Some(WEvent::Refresh) => {
+                window.refresh();
+                window.surface().commit();
+            }
+            Some(WEvent::Configure { new_size, .. }) => {
+                if let Some((w, h)) = new_size {
+                    window.resize(w, h);
+                    dimensions = (w, h)
+                }
+                window.refresh();
+                if let Some(pool) = pools.pool() {
+                    redraw(
+                        pool,
+                        window.surface(),
+                        dimensions,
+                        &font_data,
+                        cb_contents.lock().unwrap().clone(),
+                    );
+                }
+            }
+            None => {}
+        }
+
+        if need_redraw.swap(false, atomic::Ordering::Relaxed) {
+            if let Some(pool) = pools.pool() {
+                redraw(
+                    pool,
+                    window.surface(),
+                    dimensions,
+                    &font_data,
+                    cb_contents.lock().unwrap().clone(),
+                );
+            }
+            window
+                .surface()
+                .damage_buffer(0, 0, dimensions.0 as i32, dimensions.1 as i32);
+            window.surface().commit();
+        }
+
+        event_queue.dispatch().unwrap();
+    }
+}
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+fn redraw(
+    pool: &mut MemPool,
+    surface: &wl_surface::WlSurface,
+    dimensions: (u32, u32),
+    font_data: &[u8],
+    cb_contents: String,
+) {
+    use andrew::shapes::rectangle;
+    use andrew::text;
+
+    let (buf_x, buf_y) = (dimensions.0 as usize, dimensions.1 as usize);
+
+    pool.resize(4 * buf_x * buf_y)
+        .expect("Failed to resize the memory pool.");
+
+    let mut buf = vec![0; 4 * buf_x * buf_y];
+    let mut canvas =
+        andrew::Canvas::new(&mut buf, buf_x, buf_y, 4 * buf_x, andrew::Endian::native());
+
+    let bg = rectangle::Rectangle::new((0, 0), (buf_x, buf_y), None, Some([255, 170, 20, 45]));
+    canvas.draw(&bg);
+
+    let text_box = rectangle::Rectangle::new(
+        (buf_x / 30, buf_y / 35),
+        (buf_x - 2 * (buf_x / 30), (buf_x as f32 / 14.) as usize),
+        Some((3, [255, 255, 255, 255], rectangle::Sides::ALL, Some(4))),
+        None,
+    );
+    canvas.draw(&text_box);
+
+    let helper_text = text::Text::new(
+        (buf_x / 25, buf_y / 30),
+        [255, 255, 255, 255],
+        font_data,
+        buf_x as f32 / 40.,
+        2.0,
+        "Press space to draw clipboard contents",
+    );
+    canvas.draw(&helper_text);
+
+    let helper_text = text::Text::new(
+        (
+            buf_x / 25,
+            (buf_y as f32 / 30. + buf_x as f32 / 40.) as usize,
+        ),
+        [255, 255, 255, 255],
+        font_data,
+        buf_x as f32 / 40.,
+        2.0,
+        "Press 's' to store example text to clipboard",
+    );
+    canvas.draw(&helper_text);
+
+    for i in (0..cb_contents.len()).step_by(36) {
+        let content = if cb_contents.len() < i + 36 {
+            cb_contents[i..].to_string()
+        } else {
+            cb_contents[i..i + 36].to_string()
+        };
+        let text = text::Text::new(
+            (
+                buf_x / 10,
+                (buf_y as f32 / 10. + buf_x as f32 / 20. + i as f32 * buf_y as f32 / 1000.)
+                    as usize,
+            ),
+            [255, 255, 255, 255],
+            font_data,
+            buf_x as f32 / 40.,
+            2.0,
+            content,
+        );
+        canvas.draw(&text);
+    }
+
+    pool.seek(SeekFrom::Start(0)).unwrap();
+    pool.write_all(canvas.buffer).unwrap();
+    pool.flush().unwrap();
+
+    let new_buffer = pool.buffer(
+        0,
+        buf_x as i32,
+        buf_y as i32,
+        4 * buf_x as i32,
+        wl_shm::Format::Argb8888,
+    );
+    surface.attach(Some(&new_buffer), 0, 0);
+    surface.commit();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ limitations under the License.
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 extern crate x11_clipboard as x11_clipboard_crate;
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate smithay_clipboard;
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate wayland_client;
 
 #[cfg(windows)]
 extern crate clipboard_win;
@@ -38,6 +42,8 @@ pub use common::ClipboardProvider;
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 pub mod x11_clipboard;
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+pub mod wayland_clipboard;
 
 #[cfg(windows)]
 pub mod windows_clipboard;

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 Avraham Weinstock
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use smithay_clipboard::WaylandClipboard;
+use wayland_client::Display;
+
+use std::error::Error;
+
+pub struct WaylandClipboardContext(WaylandClipboard, String);
+
+impl WaylandClipboardContext {
+    pub fn new(display: &Display) -> Result<Self, Box<Error>> {
+        let clipboard = WaylandClipboard::new_threaded(display);
+        Ok(WaylandClipboardContext(clipboard, "seat0".to_string()))
+    }
+    pub fn get_contents(&mut self) -> Result<String, Box<Error>> {
+        Ok(self.0.load(self.1.clone()))
+    }
+    pub fn set_contents(&mut self, data: String) -> Result<(), Box<Error>> {
+        Ok(self.0.store(self.1.clone(), data))
+    }
+    pub fn set_seat(&mut self, name: String) {
+        self.1 = name
+    }
+}


### PR DESCRIPTION
There are a few specifics to do with wayland design that sets this implementation apart from others such as x11

1. A wayland window must be created by the client and have focus before setting or getting the clipboard contents 
2. Wayland events must be continuously dispatched for the clipboard to work. smithay-clipboard's `new_threaded()` method takes care of this using a thread that continuously dispatches those events
3. You need to specify the name of the seat you want to use to access the clipboard from (each seat has a different clipboard). By default I've set it to `seat0` as multiple seats are an exotic thing in the wayland ecosystem however it can be changed with the `set_seat()` function.
4. A wayland display must be passed to the creation of the clipboard and that must be the same display what the window is using
 
I've left the default `ClipboardContext` set to `X11ClipboardContext` on linux and I think that allowing the user to directly use `WaylandClipboardContext` at their discretion to fit their needs would be a good enough API.

I've also added a wayland example to test out the implementation.