### PR TITLE
Add Wayland support based on wl-clipboard-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 failure = "0.1"
-wl-clipboard-rs = "0.2"
+smithay-clipboard = "0.1"
+wayland-client = "*"
+wl-clipboard-rs = "0.3"
 x11-clipboard = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
+wayland-client = "0.23"
 x11-clipboard = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ objc-foundation = "0.1"
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 failure = "0.1"
 smithay-clipboard = "0.1"
-wayland-client = "*"
+wayland-client = "0.22"
 wl-clipboard-rs = "0.3"
 x11-clipboard = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
-wayland-client = "0.23"
+wayland-client = { version = "0.23", features = ["native_lib", "dlopen"] }
 x11-clipboard = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
-wayland-client = { version = "0.23", features = ["native_lib", "dlopen"] }
+failure = "0.1"
+wl-clipboard-rs = "0.2"
 x11-clipboard = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,12 @@ limitations under the License.
 extern crate failure;
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate smithay_clipboard;
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate wayland_client;
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 extern crate wl_clipboard_rs;
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@ limitations under the License.
 #![crate_type = "rlib"]
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
-extern crate wayland_client;
+extern crate failure;
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate wl_clipboard_rs;
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 extern crate x11_clipboard as x11_clipboard_crate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ limitations under the License.
 #![crate_type = "rlib"]
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+extern crate wayland_client;
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 extern crate x11_clipboard as x11_clipboard_crate;
 
 #[cfg(windows)]
@@ -35,6 +38,9 @@ extern crate objc_foundation;
 
 mod common;
 pub use common::ClipboardProvider;
+
+#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+pub mod wayland_clipboard;
 
 #[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 pub mod x11_clipboard;

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -14,21 +14,124 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::error::Error;
 use common::*;
+use failure::Fail;
+use std::{
+    error::Error,
+    io::{self, Read},
+};
+use wl_clipboard_rs::{
+    copy::{self, Options, ServeRequests},
+    paste, ClipboardType,
+};
 
-pub struct WaylandClipboardContext();
+pub struct WaylandClipboardContext {
+    supports_primary_selection: bool,
+}
 
 impl ClipboardProvider for WaylandClipboardContext {
     fn new() -> Result<WaylandClipboardContext, Box<dyn Error>> {
-        unimplemented!()
+        if let Err(e) = paste::get_contents(
+            ClipboardType::Primary,
+            paste::Seat::Unspecified,
+            paste::MimeType::Any,
+        ) {
+            match e {
+                paste::Error::NoSeats | paste::Error::ClipboardEmpty | paste::Error::NoMimeType => {
+                    Ok(WaylandClipboardContext {
+                        supports_primary_selection: true,
+                    })
+                }
+                paste::Error::PrimarySelectionUnsupported => Ok(WaylandClipboardContext {
+                    supports_primary_selection: false,
+                }),
+                _ => Err(Box::new(e.compat())),
+            }
+        } else {
+            Ok(WaylandClipboardContext {
+                supports_primary_selection: true,
+            })
+        }
     }
 
     fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
-        unimplemented!()
+        if self.supports_primary_selection {
+            if let Ok((mut reader, _)) = paste::get_contents(
+                ClipboardType::Primary,
+                paste::Seat::Unspecified,
+                paste::MimeType::Text,
+            ) {
+                // strange, but rustc won't convert Box<io::Error> into Box<dyn Error> implicitly
+                return Ok(read_into_string(&mut reader).map_err(Box::new)?);
+            }
+        }
+
+        let mut reader = paste::get_contents(
+            ClipboardType::Regular,
+            paste::Seat::Unspecified,
+            paste::MimeType::Text,
+        )
+        .map_err(into_boxed_error)?
+        .0;
+
+        Ok(read_into_string(&mut reader).map_err(Box::new)?)
     }
 
     fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
-        unimplemented!()
+        let mut options = Options::new();
+
+        options
+            .seat(copy::Seat::All)
+            .trim_newline(false)
+            .foreground(false)
+            .serve_requests(ServeRequests::Unlimited);
+
+        if self.supports_primary_selection {
+            options
+                .clipboard(ClipboardType::Primary)
+                .copy(copy::Source::Bytes(data.as_bytes()), copy::MimeType::Text)
+                .map_err(into_boxed_error)?;
+        }
+
+        options
+            .clipboard(ClipboardType::Regular)
+            .copy(copy::Source::Bytes(data.as_bytes()), copy::MimeType::Text)
+            .map_err(into_boxed_error)
+    }
+}
+
+fn into_boxed_error<F: 'static + Fail>(fail: F) -> Box<dyn Error> {
+    Box::new(fail.compat())
+}
+
+fn read_into_string<R: Read>(reader: &mut R) -> io::Result<String> {
+    let mut contents = String::new();
+    reader.read_to_string(&mut contents)?;
+
+    Ok(contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn wayland_test() {
+        let mut clipboard =
+            WaylandClipboardContext::new().expect("couldn't create a Wayland clipboard");
+
+        clipboard
+            .set_contents("foo bar baz".to_string())
+            .expect("couldn't set contents of Wayland clipboard");
+
+        std::thread::sleep(std::time::Duration::from_secs(5));
+
+        assert_eq!(
+            clipboard
+                .get_contents()
+                .expect("couldn't get contents of Wayland clipboard"),
+            "foo bar baz"
+        );
     }
 }

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 Gregory Meyer
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::error::Error;
+use common::*;
+
+pub struct WaylandClipboardContext();
+
+impl ClipboardProvider for WaylandClipboardContext {
+    fn new() -> Result<WaylandClipboardContext, Box<dyn Error>> {
+        unimplemented!()
+    }
+
+    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+
+    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
+        unimplemented!()
+    }
+}

--- a/src/wayland_clipboard.rs
+++ b/src/wayland_clipboard.rs
@@ -125,8 +125,6 @@ mod tests {
             .set_contents("foo bar baz".to_string())
             .expect("couldn't set contents of Wayland clipboard");
 
-        std::thread::sleep(std::time::Duration::from_secs(5));
-
         assert_eq!(
             clipboard
                 .get_contents()


### PR DESCRIPTION
This pull request adds `mod wayland_clipboard` and implements `WaylandClipboardContext` within. `wl-clipboard-rs` does most of the heavy lifting here, but `WaylandClipboardContext` has the following characteristics:

- When copying, copies to all seats. If the primary selection protocol is supported, copies there as well.
- When pasting, pastes from an arbitrary seat [depending on the order returned by the compositor](https://docs.rs/wl-clipboard-rs/0.2.0/wl_clipboard_rs/paste/enum.Seat.html#variant.Unspecified). If the primary selection protocol is supported, prefers to paste from that.
- Only works with text MIME types.

Implementing a `CompositeClipboardContext` should be fairly simple; first attempt to create a `WaylandClipboardContext`, then attempt to create an `X11ClipboardContext` if the Wayland implementation fails for some reason or another.