### PR TITLE
Improve Travis builds and use headless x11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,30 @@
+---
 language: rust
 
 os:
-- linux
-- osx
+  - linux
+  - osx
 
-# TODO: figure out how to get headless X11 working
-script: |
-  #!/bin/bash
-  cargo build --verbose
-  if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-    cargo build --tests --verbose
-  else
-    cargo test --verbose
-  fi
+rust:
+  - stable
+  - beta
+  - nightly
+
+services:
+  - xvfb                      # Fake X11
+
+addons:
+  apt:
+    packages:
+      - libxcb-shape0-dev     # Because we use X11
+      - libxcb-xfixes0-dev    # Because we use X11
+
+cache: cargo
+matrix:
+  allow_failures:
+    - rust: nightly
+
+script:
+  - cargo clean
+  - cargo build
+  - cargo test


### PR DESCRIPTION
## Description
I'm using your crate on my [side project](https://github.com/alexandrebouthinon/auth-o-tron) and like you I was unable to make unit tests pass on Linux. I search in the Travis documentation and found [this](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services). I share you the `.travis.yml` I use. 