### PR TITLE
Fix Travis CI build, add XCB build requirements, used in x11-clipboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ os:
 # TODO: figure out how to get headless X11 working
 script: |
   #!/bin/bash
+  if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+    apt-get update
+    apt-get install -y --no-install-recommends xorg-dev python3 libx11-xcb-dev libgl1-mesa-dev
+  fi
   cargo build --verbose
   if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
     cargo build --tests --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,18 @@ os:
 - linux
 - osx
 
+addons:
+  apt:
+    update: true
+    packages:
+    - xorg-dev
+    - python3
+    - libx11-xcb-dev
+    - libgl1-mesa-dev
+
 # TODO: figure out how to get headless X11 working
 script: |
   #!/bin/bash
-  if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-    apt-get update
-    apt-get install -y --no-install-recommends xorg-dev python3 libx11-xcb-dev libgl1-mesa-dev
-  fi
   cargo build --verbose
   if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
     cargo build --tests --verbose


### PR DESCRIPTION
The Travis CI build currently fails on Linux due to new XCB requirements (in `rust-clipboard -> x11-clipboard -> xcb`).

This PR fixes that by installing the needed dependencies.