### PR TITLE
Update to Rust edition 2018

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -16,19 +16,19 @@ limitations under the License.
 
 use std::error::Error;
 
-pub fn err(s: &str) -> Box<Error> {
-    Box::<Error + Send + Sync>::from(s)
+pub fn err(s: &str) -> Box<dyn Error> {
+    Box::<dyn Error + Send + Sync>::from(s)
 }
 
 /// Trait for clipboard access
 pub trait ClipboardProvider: Sized {
     /// Create a context with which to access the clipboard
-    // TODO: consider replacing Box<Error> with an associated type?
-    fn new() -> Result<Self, Box<Error>>;
+    // TODO: consider replacing Box<dyn Error> with an associated type?
+    fn new() -> Result<Self, Box<dyn Error>>;
     /// Method to get the clipboard contents as a String
-    fn get_contents(&mut self) -> Result<String, Box<Error>>;
+    fn get_contents(&mut self) -> Result<String, Box<dyn Error>>;
     /// Method to set the clipboard contents as a String
-    fn set_contents(&mut self, String) -> Result<(), Box<Error>>;
+    fn set_contents(&mut self, String) -> Result<(), Box<dyn Error>>;
     // TODO: come up with some platform-agnostic API for richer types
     // than just strings (c.f. issue #31)
 }

--- a/src/nop_clipboard.rs
+++ b/src/nop_clipboard.rs
@@ -20,15 +20,15 @@ use std::error::Error;
 pub struct NopClipboardContext;
 
 impl ClipboardProvider for NopClipboardContext {
-    fn new() -> Result<NopClipboardContext, Box<Error>> {
+    fn new() -> Result<NopClipboardContext, Box<dyn Error>> {
         Ok(NopClipboardContext)
     }
-    fn get_contents(&mut self) -> Result<String, Box<Error>> {
+    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
         println!("Attempting to get the contents of the clipboard, which hasn't yet been \
                   implemented on this platform.");
         Ok("".to_string())
     }
-    fn set_contents(&mut self, _: String) -> Result<(), Box<Error>> {
+    fn set_contents(&mut self, _: String) -> Result<(), Box<dyn Error>> {
         println!("Attempting to set the contents of the clipboard, which hasn't yet been \
                   implemented on this platform.");
         Ok(())

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -50,11 +50,11 @@ impl<S> ClipboardProvider for X11ClipboardContext<S>
 where
     S: Selection,
 {
-    fn new() -> Result<X11ClipboardContext<S>, Box<Error>> {
+    fn new() -> Result<X11ClipboardContext<S>, Box<dyn Error>> {
         Ok(X11ClipboardContext(X11Clipboard::new()?, PhantomData))
     }
 
-    fn get_contents(&mut self) -> Result<String, Box<Error>> {
+    fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
         Ok(String::from_utf8(self.0.load(
             S::atom(&self.0.getter.atoms),
             self.0.getter.atoms.utf8_string,
@@ -63,7 +63,7 @@ where
         )?)?)
     }
 
-    fn set_contents(&mut self, data: String) -> Result<(), Box<Error>> {
+    fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
         Ok(self.0.store(
             S::atom(&self.0.setter.atoms),
             self.0.setter.atoms.utf8_string,


### PR DESCRIPTION
This PR updates the project to Rust edition 2018.

The Travis CI build currently fails due to missing dependencies in CI. This is fixed separately in #73 .