### PR TITLE
Put platform implementations behind feature toggles, enable by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,20 @@ repository = "https://github.com/aweinstock314/rust-clipboard"
 license = "MIT / Apache-2.0"
 keywords = ["clipboard"]
 
+[features]
+default = ["macos", "windows", "x11"]
+
+macos = ["objc", "objc_id", "objc-foundation"]
+windows = ["clipboard-win"]
+x11 = ["x11-clipboard"]
+
 [target.'cfg(windows)'.dependencies]
-clipboard-win = "2.1"
+clipboard-win = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2"
-objc_id = "0.1"
-objc-foundation = "0.1"
+objc = { version = "0.2", optional = true }
+objc_id = { version = "0.1", optional = true }
+objc-foundation = { version = "0.1", optional = true }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
-x11-clipboard = "0.3"
+x11-clipboard = { version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,43 +19,43 @@ limitations under the License.
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
-#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+#[cfg(all(unix, feature = "x11", not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 extern crate x11_clipboard as x11_clipboard_crate;
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "windows"))]
 extern crate clipboard_win;
 
-#[cfg(target_os="macos")]
+#[cfg(all(target_os="macos", feature = "macos"))]
 #[macro_use]
 extern crate objc;
-#[cfg(target_os="macos")]
+#[cfg(all(target_os="macos", feature = "macos"))]
 extern crate objc_id;
-#[cfg(target_os="macos")]
+#[cfg(all(target_os="macos", feature = "macos"))]
 extern crate objc_foundation;
 
 mod common;
 pub use common::ClipboardProvider;
 
-#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+#[cfg(all(unix, feature = "x11", not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 pub mod x11_clipboard;
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "windows"))]
 pub mod windows_clipboard;
 
-#[cfg(target_os="macos")]
+#[cfg(all(target_os="macos", feature = "macos"))]
 pub mod osx_clipboard;
 
 pub mod nop_clipboard;
 
-#[cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
+#[cfg(all(unix, feature = "x11", not(any(target_os="macos", target_os="android", target_os="emscripten"))))]
 pub type ClipboardContext = x11_clipboard::X11ClipboardContext;
-#[cfg(windows)]
+#[cfg(all(windows, feature = "windows"))]
 pub type ClipboardContext = windows_clipboard::WindowsClipboardContext;
-#[cfg(target_os="macos")]
+#[cfg(all(target_os="macos", feature = "macos"))]
 pub type ClipboardContext = osx_clipboard::OSXClipboardContext;
 #[cfg(target_os="android")]
 pub type ClipboardContext = nop_clipboard::NopClipboardContext; // TODO: implement AndroidClipboardContext (see #52)
-#[cfg(not(any(unix, windows, target_os="macos", target_os="android", target_os="emscripten")))]
+#[cfg(not(any(all(unix, feature = "x11", not(any(target_os="macos", target_os="android", target_os="emscripten"))), all(windows, feature = "windows"), all(target_os="macos", feature = "macos"), target_os="android")))]
 pub type ClipboardContext = nop_clipboard::NopClipboardContext;
 
 #[test]


### PR DESCRIPTION
This adds a compiler feature for each platform implementation (namely `windows`, `macos` and `x11`). All are enabled by default so nothing is changed.

I'd like this because I've `rust-clipboard` as dependency for traits, but I don't want to build with the nasty new XCB dependencies the X11 clipboard provider implementation requires.

The Travis CI build currently fails due to these missing dependencies in CI as well. This is fixed separately in #73 .