### PR TITLE
Update x11-clipboard dependency to use xcb 0.5.1, fixes docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
-x11-clipboard = "0.3"
+x11-clipboard = "0.5.1"


### PR DESCRIPTION
Builds on docs.rs currently fails for all new crate releases that use `rust-clipboard`. This is caused by `x11-clipboard -> xcb`. A newer version of both fixes this.

The Travis CI build currently fails due to these missing dependencies in CI as well. This is fixed separately in #73 .