### PR TITLE
Fix crates.io badge and add readme to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "clipboard"
 version = "0.5.0"
 authors = ["Avi Weinstock <aweinstock314@gmail.com>"]
 description = "rust-clipboard is a cross-platform library for getting and setting the contents of the OS-level clipboard."
+readme = "README.md"
 repository = "https://github.com/aweinstock314/rust-clipboard"
 license = "MIT / Apache-2.0"
 keywords = ["clipboard"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ rust-clipboard is a cross-platform library for getting and setting the contents 
 It has been tested on Windows, Mac OSX, GNU/Linux, and FreeBSD.
 It is used in Mozilla Servo.
 
-[![](http://meritbadge.herokuapp.com/clipboard)](https://crates.io/crates/clipboard)
+[![crates.io](https://img.shields.io/crates/v/clipboard)](https://crates.io/crates/clipboard)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/aweinstock314/rust-clipboard)](https://ci.appveyor.com/project/aweinstock314/rust-clipboard)
 [![Travis Build Status](https://travis-ci.org/aweinstock314/rust-clipboard.svg?branch=master)](https://travis-ci.org/aweinstock314/rust-clipboard)
 


### PR DESCRIPTION
Adding the readme field to Cargo.toml will allow the readme file content to be displayed on the crates.io page.